### PR TITLE
Fixes to videoChat

### DIFF
--- a/src/services/videoChat.ts
+++ b/src/services/videoChat.ts
@@ -84,7 +84,10 @@ export namespace videoChat {
     if (!localMediaStream) {
       return;
     }
+    // FIX: when you stop a video track, it can never be reopened
+    // set localMediaStream to be null
     localMediaStream.getVideoTracks()[0].stop();
+    localMediaStream = null;
   }
   export function getUserMedia() {
     if (!_isSupported) {


### PR DESCRIPTION
- when you stop a video track, it can never be reopened
- so I changed it to be set to null instead

the previous bug was: enable videochat -> add contact -> go back to playing screen -> your videostream is gone