### PR TITLE
Bug Fix to Draggable Pieces

### DIFF
--- a/src/services/matchStateHelper.ts
+++ b/src/services/matchStateHelper.ts
@@ -22,7 +22,7 @@ export class MatchStateHelper {
   dragTo(pieceIndex: number, x: number, y: number) {
     checkCondition('dragToXY', -100 <= x && x <= 100 && -100 <= y && y <= 100);
     const pieceSpec = this.getPieceSpec(pieceIndex);
-    checkCondition('dragTo', pieceSpec.isDraggable);
+    checkCondition('dragTo', pieceSpec.isDraggable || pieceSpec.elementKind === 'standard');
     const pieceState = this.getPieceState(pieceIndex);
     pieceState.x = x;
     pieceState.y = y;


### PR DESCRIPTION
- In board, draggable={pieceSpec.element.isDraggable || kind === 'standard'}
- However in matchStateHelper: checkCondition('dragTo', pieceSpec.isDraggable)
- So update that to allow dragging of standard pieces as well
- (fixes one of the games as well)